### PR TITLE
fix: check if key exist to prevent PHP Notice

### DIFF
--- a/action.php
+++ b/action.php
@@ -141,12 +141,16 @@ class action_plugin_newpagetemplate extends DokuWiki_Action_Plugin {
     }
   }
 
-  function check_acl(Doku_Event $event,$param) {
-    if(strlen(trim($_REQUEST['newpagetemplate']))>0) {
-       $pg = trim($_REQUEST['newpagetemplate'],':');
-       $auth =auth_quickaclcheck($pg);	
-	   if($auth < 4)   $this->allow = false;
-	   }
+  public function check_acl(Doku_Event $event,$param) {
+      global $INPUT;
+      if (!$INPUT->has('newpagetemplate')) {
+          return;
+      }
+
+      $pq = trim($INPUT->str('newpagetemplate'), ':');
+      if (auth_quickaclcheck($pq) < AUTH_CREATE) {
+          $this->allow = false;
+      }
    }
    
   function write_msg (&$event,$param) {


### PR DESCRIPTION
Also rewrite this function to be more readable.